### PR TITLE
ANP-35 Added cors policy and port is set to 32770

### DIFF
--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -7,6 +7,7 @@
     <UserSecretsId>9af15eea-b2d9-4dfd-aa10-033e8e01b64d</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
+	<DockerfileRunArguments>-p "32770:443" -p "32771:80"</DockerfileRunArguments>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added cors policy for production and for deployment, for now production is set to localhost:4200 because we don't know where our website will be.
Also now backend API will always run on port 32770.