### PR TITLE
Dev android/anp 60 ble fix

### DIFF
--- a/android/BLE/src/main/java/hr/foi/air/wattsup/ble/BLEManager.kt
+++ b/android/BLE/src/main/java/hr/foi/air/wattsup/ble/BLEManager.kt
@@ -41,7 +41,6 @@ class BLEManager(
     private var scanCallback: ScanCallback? = null
 
     init {
-        requestBluetoothPermissions(context)
         initializeBluetooth()
     }
 

--- a/android/app/src/main/java/hr/foi/air/wattsup/MainActivity.kt
+++ b/android/app/src/main/java/hr/foi/air/wattsup/MainActivity.kt
@@ -1,6 +1,11 @@
 package hr.foi.air.wattsup
 
 import ScanViewModel
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -9,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -21,11 +28,24 @@ import hr.foi.air.wattsup.ui.theme.WattsUpTheme
 import hr.foi.air.wattsup.viewmodels.ChargerViewModel
 
 class MainActivity : ComponentActivity() {
+
+    private val REQUEST_PERMISSIONS = 1
+
+    private val REQUIRED_PERMISSIONS = arrayOf(
+        Manifest.permission.BLUETOOTH,
+        Manifest.permission.BLUETOOTH_ADMIN,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.BLUETOOTH_SCAN,
+    )
+
     private val chargerViewModel: ChargerViewModel by viewModels()
     private val scanViewModel: ScanViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestPermissions(this)
         setContent {
             WattsUpTheme {
                 Surface(
@@ -63,6 +83,21 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private fun requestPermissions(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val permissionsToRequest = REQUIRED_PERMISSIONS.filter {
+                ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
+            }
+            if (permissionsToRequest.isNotEmpty()) {
+                ActivityCompat.requestPermissions(
+                    context as Activity,
+                    permissionsToRequest.toTypedArray(),
+                    REQUEST_PERMISSIONS,
+                )
             }
         }
     }

--- a/android/app/src/main/java/hr/foi/air/wattsup/viewmodels/ScanViewModel.kt
+++ b/android/app/src/main/java/hr/foi/air/wattsup/viewmodels/ScanViewModel.kt
@@ -55,6 +55,14 @@ class ScanViewModel(application: Application) : AndroidViewModel(application) {
         }
 
     fun startBLEScanning(onScan: () -> Unit) {
+        if (!bleManager.isBluetoothEnabled()) {
+            bleManager.stopScanning()
+            _scanning.value = false
+            _scanSuccess.value = false
+            _userMessage.value = "Bluetooth is not enabled on this device"
+            return
+        }
+
         _includeTestButton.value = false
         _scanning.value = true
 

--- a/android/app/src/main/java/hr/foi/air/wattsup/viewmodels/ScanViewModel.kt
+++ b/android/app/src/main/java/hr/foi/air/wattsup/viewmodels/ScanViewModel.kt
@@ -125,6 +125,7 @@ class ScanViewModel(application: Application) : AndroidViewModel(application) {
     private fun handleBLEScanResult(result: ScanResult?, onScan: () -> Unit) {
         if (result != null) {
             val device = result.device
+            Log.i("BLUETOOTH", "Scanned: $device")
             if (device.address == BLEtargetDeviceAddress) {
                 // The target BLE device is detected
                 _scanSuccess.value = true


### PR DESCRIPTION
Moved requesting permissions to MainActivity, since context for permissions requires Activity and not Application context, and instantiating it anywhere else (ViewModel, via dependency injection etc) doesn't work with passing proper context.
Prevented scanning in case Bluetooth disabled.